### PR TITLE
Srfi + eval

### DIFF
--- a/tests/test-driver.rkt
+++ b/tests/test-driver.rkt
@@ -82,7 +82,8 @@
                         [set-cdr! (syntax-rules () [(_ p v) (set-mcdr! p v)])]
                         [car (syntax-rules () [(_ p) (mcar p)])]
                         [cdr (syntax-rules () [(_ p) (mcdr p)])])
-             ,x))))
+             ,x)
+          (make-base-namespace))))
   
 (define test-one
   (case-lambda


### PR DESCRIPTION
Includes both removing srfi from pass.rkt, and making eval work for unit tests not as a script.

I'd be happy to split out these two pull requests if you'd rather (they are already two different commits).

To run the unit tests, at the moment you can do:

raco test test-all.rkt

(In this case you could also do `racket test-all.rkt` as well).
