### PR TITLE
Make generated records transparent

### DIFF
--- a/private/records.rkt
+++ b/private/records.rkt
@@ -594,6 +594,7 @@
               #`(begin
                   (define-struct (#,(pair-alt-name alt) #,(ntspec-struct-name ntspec))
                     (fld ...)
+                    #:transparent
                     #:constructor-name $maker)
                   (define #,(pair-alt-maker alt)
                     (lambda (who fld ... msg ...)


### PR DESCRIPTION
Making the generated records transparent makes debugging easier.
